### PR TITLE
Experiment gulp css clean

### DIFF
--- a/assets/stylus/components/article.styl
+++ b/assets/stylus/components/article.styl
@@ -6,7 +6,7 @@
     
 .Article
   // position relative
-  // width $break-lg-val - 4em
+  // width $break-767-val - 4em
   // mautoargin 0 
   // margin 0em 10em
   padding 0em 4em
@@ -24,10 +24,10 @@
   img
     padding-bottom 1.4em
     
-  // @media $break-sm
+  // @media $break-767
   //   padding 0em .85em
     
-  @media $break-md-lg
+  @media $break-767
     padding 0em .85em
     
 .Article-summary-list

--- a/assets/stylus/components/banner.styl
+++ b/assets/stylus/components/banner.styl
@@ -10,7 +10,7 @@ banner_container(min_h=55vh,padding=10em 5em 10em 5em)
   // min-height min_h
   padding padding
   
-  @media $break-sm
+  @media $break-767
     // min-height min_h - 10
     padding padding[0] .8em padding[2] .8em
 
@@ -37,7 +37,7 @@ banner_container(min_h=55vh,padding=10em 5em 10em 5em)
   color #515151 // move to h1 styles or darken color
   font-size 2.2em
   
-  @media $break-lg
+  @media $break-767
     font-size 2.4em 
   
 .Banner-subtitle

--- a/assets/stylus/components/blog.styl
+++ b/assets/stylus/components/blog.styl
@@ -15,7 +15,7 @@
   &:active
     background $link-hover-color  
 
-  @media $break-sm
+  @media $break-767
     padding 3em .8em 3em .8em
 
 
@@ -65,11 +65,11 @@
   letter-spacing .01em  
   text-align center 
   
-  @media $break-lg
+  @media $break-767
     // big screen
     font-size 1.1em 
     
-  @media $break-sm
+  @media $break-767
     // small screen
     font-size 1.05em 
     

--- a/assets/stylus/components/buttons.styl
+++ b/assets/stylus/components/buttons.styl
@@ -19,14 +19,14 @@ button(bkg=transparent,fontSize=1em,fontWeight=700,pad=1em .1em,border=1px solid
 .Button-player
 	button()
 	
-	@media $break-md-lg
+	@media $break-767
 		margin-bottom 0.5em
 	
 .Button-dataset
 	button()
 	margin-left 0.65em
 	
-	@media $break-md-lg
+	@media $break-767
 		margin-left 0em
 
 .Button-inverse

--- a/assets/stylus/components/cart.styl
+++ b/assets/stylus/components/cart.styl
@@ -90,7 +90,7 @@ tr.Cart-orderItem td
     // font-size $removeSize*$scaleRemove
     transform scale($scaleRemove)
 
-  @media $break-md
+  @media $break-767
     margin-right .5em
 
 .no-touch
@@ -119,7 +119,7 @@ tr.Cart-orderItem td
   margin 0.25em
   transition border-color .3s ease-in-out, transform .35s ease-in-out
   
-  @media $break-sm
+  @media $break-767
     border-width 0px $smw $smw $smw
   
 .Cart--triangle-down
@@ -131,7 +131,7 @@ tr.Cart-orderItem td
   margin 0.25em
   transition border-color .3s ease-in-out, transform .35s ease-in-out
   
-  @media $break-sm
+  @media $break-767
     border-width $smw $smw 0px $smw
   
 #Cart-empty
@@ -149,7 +149,7 @@ tr.Cart-orderItem td
       transform scale($scale)
       border-color complement($link-hover-color) transparent transparent transparent
 
-  @media $break-md
+  @media $break-767
     margin-left .5em
 
 
@@ -173,19 +173,19 @@ tr.Cart-orderItem td
         border-color $link-hover-color transparent transparent transparent
 
 .Cart-costCalc  
-  @media $break-md
+  @media $break-767
     font-size .9em
     
 .Cart-costCalc--subTotal
   font-weight 700
   
-  @media $break-md
+  @media $break-767
     font-size .9em
     text-align right
 
 
 #CartItem-unitCost
-  @media $break-md
+  @media $break-767
     // flex 0 0 (2/3)*100%
     max-width (2/3)*100%
     text-align right
@@ -193,11 +193,11 @@ tr.Cart-orderItem td
 #CartItem-equalSign
   text-align center
   
-  @media $break-md
+  @media $break-767
     text-align left
   
 #CartItem-unitQuant
-  @media $break-md
+  @media $break-767
 
     text-align right
     

--- a/assets/stylus/components/feature.styl
+++ b/assets/stylus/components/feature.styl
@@ -26,13 +26,13 @@
 .Feature--padded2
   padding 2em
   
-  @media $break-sm
+  @media $break-767
     padding 3em .8em 3em .8em 
         
 .Feature--padded3
   padding 3em 
   
-  @media $break-sm
+  @media $break-767
     padding 3em .8em 3em .8em 
     
 .Feature-image--wrapper
@@ -87,7 +87,7 @@
   margin-right auto
   height auto
 
-  @media $break-lg
+  @media $break-767
     max-width 60%
 
 .Feature-image--dev
@@ -98,7 +98,7 @@
   margin-right auto
   height auto
   
-  @media $break-sm
+  @media $break-767
     max-width 80%
 
 .Feature-image--store
@@ -126,7 +126,7 @@
   text-align justify
   text-justify inter-word
   
-  @media $break-lg
+  @media $break-767
       font-size 1.15em
       
   > p
@@ -139,7 +139,7 @@
   font-weight $subhead-font-weight
 
   
-  @media $break-lg
+  @media $break-767
       font-size 1.4em
         
 .Feature-image--configWorld

--- a/assets/stylus/components/grid.styl
+++ b/assets/stylus/components/grid.styl
@@ -83,7 +83,7 @@
 .Grid-cell--1of2
 	flex 0 0 50%
 	
-	@media $break-md-lg
+	@media $break-767
 		flex 0 0 100%
 	
 .Grid-cell--1of3
@@ -123,20 +123,20 @@
 	border-left 0
 	
 .Grid-cell--cartFormula
-	@media $break-md
+	@media $break-767
 		flex 0 0 100%
 		width 100%
 
 .Grid--cartFormula-break
 	align-items center
 
-	@media $break-md
+	@media $break-767
 		flex-direction column
 		align-items stretch
 		
 
 .Grid-cell--cartSum
-	@media $break-md
+	@media $break-767
 		border-top 1px solid gray
 		margin-top .5em
 		padding-bottom .5em
@@ -265,7 +265,7 @@
 	max-width 50%
 	padding 1em 0em 0em 1em
 
-	@media $break-md
+	@media $break-767
 		flex 0 0 100%
 		max-width 100%
 
@@ -275,7 +275,7 @@
 	max-width 33.3333%
 	padding 1em 0em 0em 1em
 
-	@media $break-md
+	@media $break-767
 		flex 0 0 100%
 		max-width 100%
 
@@ -285,7 +285,7 @@
 	max-width 33.33333%
 	padding 4em 1.4em 2em 1.4em
 
-	@media $break-md
+	@media $break-767
 		flex 0 0 100%
 		max-width 100%
 		
@@ -295,7 +295,7 @@
 	max-width 33.33333%
 	padding 0.5em 1.4em 1em 1.4em
 
-	@media $break-md
+	@media $break-767
 		padding 0em 
 		flex 0 0 100%
 		max-width 100%

--- a/assets/stylus/components/nav.styl
+++ b/assets/stylus/components/nav.styl
@@ -3,7 +3,7 @@
 	float left
 	list-style none
 	
-	@media $break-xs
+	@media $break-767
 		border-right 1px solid #ddd
 		width (1/6*100)%
 	

--- a/assets/stylus/components/site.styl
+++ b/assets/stylus/components/site.styl
@@ -31,7 +31,7 @@
   animation reveal .6s .2s ease both
   // top $navbar-height
   
-  // @media $break-xs
+  // @media $break-767
   //   padding-top 5.9em
 
 // .Site-content:after

--- a/assets/stylus/components/store-config.styl
+++ b/assets/stylus/components/store-config.styl
@@ -59,7 +59,7 @@ storeConfig-button($stroke=1px,$stroke_color=#ddd)
 .StoreConfig-SubTotal--label
   color #fff
   
-  @media $break-sm
+  @media $break-767
     padding-top 1em 
     padding-bottom 1em
 

--- a/assets/stylus/elements.styl
+++ b/assets/stylus/elements.styl
@@ -90,7 +90,7 @@ table
 	overflow auto 
 	text-overflow ellipsis
 
-	@media $break-md 
+	@media $break-767 
 		font-size .85em	
 // lists
 ul

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -62,12 +62,9 @@ jscoffee = ()->
     )
   .pipe concat "main.js"
   .pipe uglify()
-  .pipe gulp.dest "contents/js"
-  .pipe livereload();
+  js_sideNav()
 
 js = ()->
-  js_sideNav()
-  js_bkgVideo()
   jscoffee()
 
 gulp.task "newPost", ->
@@ -166,7 +163,8 @@ gulp.task "build_wintersmith", (cb)->
 gulp.task "css_clean", ->
   return gulp.src('build/css/main.css')
     .pipe(uncss(
-      html: ['build/**/*.html']))
+      html: ['build/**/*.html'],
+      ignore: ['.Header-bkg-transparent','.Header-bkg-transparent .Header-nav-item','.Header-bkg-opaque','.Header-nav-item','.Header-nav-item:after','.Header-nav-item:hover:after','.Header-cart-button-container','.cart-full','.Cart-table-container','.Cart-rowContainer','cursor default:hover','.no-touch','.no-touch a:hover','.no-touch .Button:hover','.no-touch .button-flex:hover','.no-touch .Button-inverse:hover','.no-touch .Button-sm:hover','.no-touch .Button--cart:hover','.no-touch .Button-player:hover','.no-touch .Button-dataset:hover','.no-touch .Button--cart:active','.Wallop-dot','.Wallop-dot--current','.Wallop-item','.Wallop-item--hidePrevious','.Wallop-item--current','.Wallop-item--showNext','.StoreConfig-world:last-child','.StoreConfig-world','.StoreConfig-eye','.StoreConfig-eye:last-child','.StoreConfig--state-active','.StoreConfig--state-inactive','.Store-license','.no-touch .Store-license:hover', '.AddtoCart','.Button-cart','.Cart--triangle-up','.Cart--triangle-down','.Cart-itemQuant--increment','.no-touch .Cart-itemQuant--increment:hover','.Cart-itemQuant--increment:active','.Cart-itemQuant--increment:active >p.Cart--triangle-up','.Cart-itemQuant--increment:active >p.Cart--triangle-down','.no-touch .Cart-itemQuant--increment:hover >p.Cart--triangle-up','.Grid-cell--1of6','.Grid-cell--top','.Grid--cartFormula-break','.Aligner-item','.Grid--gutters-lg > .Aligner-item','hr,[role="button"]','.TechSpecs-table','.TechSpecs-txt--eye', '.TechSpecs-table td', '.TechSpecs-table .TechSpecs-table--column', '.TechSpecs-table--column']))
     .pipe(gulp.dest('build/css'))
 
 

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -164,7 +164,34 @@ gulp.task "css_clean", ->
   return gulp.src('build/css/main.css')
     .pipe(uncss(
       html: ['build/**/*.html'],
-      ignore: ['.Header-bkg-transparent','.Header-bkg-transparent .Header-nav-item','.Header-bkg-opaque','.Header-nav-item','.Header-nav-item:after','.Header-nav-item:hover:after','.Header-cart-button-container','.cart-full','.Cart-table-container','.Cart-rowContainer','cursor default:hover','.no-touch','.no-touch a:hover','.no-touch .Button:hover','.no-touch .button-flex:hover','.no-touch .Button-inverse:hover','.no-touch .Button-sm:hover','.no-touch .Button--cart:hover','.no-touch .Button-player:hover','.no-touch .Button-dataset:hover','.no-touch .Button--cart:active','.Wallop-dot','.Wallop-dot--current','.Wallop-item','.Wallop-item--hidePrevious','.Wallop-item--current','.Wallop-item--showNext','.StoreConfig-world:last-child','.StoreConfig-world','.StoreConfig-eye','.StoreConfig-eye:last-child','.StoreConfig--state-active','.StoreConfig--state-inactive','.Store-license','.no-touch .Store-license:hover', '.AddtoCart','.Button-cart','.Cart--triangle-up','.Cart--triangle-down','.Cart-itemQuant--increment','.no-touch .Cart-itemQuant--increment:hover','.Cart-itemQuant--increment:active','.Cart-itemQuant--increment:active >p.Cart--triangle-up','.Cart-itemQuant--increment:active >p.Cart--triangle-down','.no-touch .Cart-itemQuant--increment:hover >p.Cart--triangle-up','.Grid-cell--1of6','.Grid-cell--top','.Grid--cartFormula-break','.Aligner-item','.Grid--gutters-lg > .Aligner-item','hr,[role="button"]','.TechSpecs-table','.TechSpecs-txt--eye', '.TechSpecs-table td', '.TechSpecs-table .TechSpecs-table--column', '.TechSpecs-table--column']))
+      ignore: [
+                new RegExp('^.no-touch.*'),
+                '.Header-bkg-transparent','.Header-bkg-transparent .Header-nav-item','.Header-bkg-opaque','.Header-nav-item','.Header-nav-item:after','.Header-nav-item:hover:after','.Header-cart-button-container',
+                '.cart-full','.Cart-table-container','.Cart-rowContainer',
+                'cursor default:hover','.no-touch','.no-touch a:hover','.no-touch .Button:hover','.no-touch .button-flex:hover','.no-touch .Button-inverse:hover','.no-touch .Button-sm:hover','.no-touch .Button--cart:hover','.no-touch .Button-player:hover','.no-touch .Button-dataset:hover','.no-touch .Button--cart:active',
+                '.Wallop-dot','.Wallop-dot--current','.Wallop-item','.Wallop-item--hidePrevious','.Wallop-item--current','.Wallop-item--showNext',
+                '.StoreConfig-world:last-child','.StoreConfig-world','.StoreConfig-eye','.StoreConfig-eye:last-child','.StoreConfig--state-active','.StoreConfig--state-inactive','.Store-license','.no-touch .Store-license:hover',
+                '.AddtoCart','.Button-cart','.Cart--triangle-up','.Cart--triangle-down','.Cart-itemQuant--increment','.no-touch .Cart-itemQuant--increment:hover','.Cart-itemQuant--increment:active','.Cart-itemQuant--increment:active >p.Cart--triangle-up','.Cart-itemQuant--increment:active >p.Cart--triangle-down','.no-touch .Cart-itemQuant--increment:hover >p.Cart--triangle-up',
+                '.Grid-cell--1of6','.Grid-cell--top','.Grid--cartFormula-break',
+                '.Aligner-item','.Grid--gutters-lg > .Aligner-item','hr,[role="button"]',
+                '.TechSpecs-table','.TechSpecs-txt--eye', '.TechSpecs-table td', '.TechSpecs-table .TechSpecs-table--column', '.TechSpecs-table--column'
+              ]))
+        # ignore: [    
+        #   new RegExp('^.Header-\.*'),
+        #   new RegExp('^.Cart-\.*'),
+        #   new RegExp('cart-full'),
+        #   new RegExp('.AddtoCart'),          
+        #   new RegExp('^.no-touch\.*'),
+        #   new RegExp('^hover\.*'),
+        #   new RegExp('^.Button-\.*'),
+        #   new RegExp('^.Wallop-\.*'),
+        #   new RegExp('^.StoreConfig-\.*'),
+        #   new RegExp('Store-license'),
+        #   new RegExp('.Grid-cell--1of6'),
+        #   new RegExp('.Grid--gutters-lg > .Aligner-item'),
+        #   new RegExp('hr,[role="button"]'),
+        #   new RegExp('^.TechSpecs-\.*')
+        # ]))
     .pipe(gulp.dest('build/css'))
 
 

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "gulp-livereload": "^3.8.0",
     "gulp-sitemap": "^4.1.1",
     "gulp-stylus": "^2.0.7",
-    "gulp-sync": "^0.1.4",
     "gulp-uglify": "^1.4.1",
+    "gulp-uncss": "^1.0.6",
     "gulp-util": "^3.0.5",
     "imagemin-pngquant": "^5.0.0",
     "minimist": "^1.2.0",
+    "run-sequence": "^1.2.2",
     "run-wintersmith": "0.0.3",
     "wintersmith-contents": "^0.5.0"
   },


### PR DESCRIPTION
Removed old breakpoints vars and replace with `break-767`
Integrate gulp-uncss into the build to remove unused css
Added a list of selectors that should not be removed by uncss and fixed .no-touch selector with RegExp
