### PR TITLE
add thumbnail meta for blogposts

### DIFF
--- a/assets/stylus/components/feature.styl
+++ b/assets/stylus/components/feature.styl
@@ -131,8 +131,11 @@
   top 0 
 
 .Feature-image--blog-archive--wrapper
-  height 20vh
+  height 30vh
   padding-bottom 3em
+  
+  @media $break-767
+    height 40vh
 
 .Background-img--blog-archive
   width 100%

--- a/contents/articles/2013-10_034-release/index.md
+++ b/contents/articles/2013-10_034-release/index.md
@@ -4,6 +4,7 @@ author: Pupil Dev Team
 date: 2013-10-21
 subtitle: We have been busy working on Pupil in the last month and want to share updates!
 featured_img: "../../../../media/images/blog/v0.3.4_release_tag.png"
+featured_img_thumb: "../../../../media/images/blog/thumb/v0.3.4_release_tag.png"
 ---
 
 We have been busy working on Pupil in the last month and want to share updates!

--- a/contents/articles/2013-11_035-release/index.md
+++ b/contents/articles/2013-11_035-release/index.md
@@ -4,6 +4,7 @@ author: Pupil Dev Team
 date: 2013-11-14
 subtitle: Another quick release of our recent development work on Pupil. Updates are recommended!
 featured_img: "../../../../media/images/blog/v0.3.5_release_tag.png"
+featured_img_thumb: "../../../../media/images/blog/thumb/v0.3.5_release_tag.png"
 ---
 
 Another quick release of our recent development work on Pupil. Updates are recommended!

--- a/contents/articles/2013-12_036-marker-tracking/index.md
+++ b/contents/articles/2013-12_036-marker-tracking/index.md
@@ -4,6 +4,7 @@ author: Pupil Dev Team
 date: 2013-12-09
 subtitle: We've been busy working on a lot of improvements in the last few weeks both on the hardware and software fronts. We're pleased to announce that we've completed a Marker Tracking plugin...
 featured_img: "../../../../media/images/blog/v0.3.6_marker_tracking.png"
+featured_img_thumb: "../../../../media/images/blog/thumb/v0.3.6_marker_tracking.png"
 ---
 
 We've been busy working on a lot of improvements in the last few weeks both on the hardware and software fronts. We're pleased to announce that we've completed a **Marker Tracking** plugin.  This is something that has been on our list for a long time, so we're pretty excited to have it up and running!  Update to v0.3.6, and let us know what you think!

--- a/contents/articles/2014-01_037-release/index.md
+++ b/contents/articles/2014-01_037-release/index.md
@@ -3,7 +3,8 @@ title: New Pupil Pro Headset + Capture Software 0.3.7
 author: Pupil Dev Team
 date: 2014-01-22
 subtitle: We're starting the new year with a lot of energy and some big updates here at Pupil Labs...
-featured_img: "../../../media/images/blog/pro-front-r20-crop.png" 
+featured_img: "../../../media/images/blog/pro-front-r20-crop.png"
+featured_img_thumb: "../../../media/images/blog/thumb/pro-front-r20-crop.png" 
 ---
 
 We're starting the new year with a lot of energy and some big updates here at Pupil Labs. 

--- a/contents/articles/2014-02_player-release/index.md
+++ b/contents/articles/2014-02_player-release/index.md
@@ -4,6 +4,7 @@ author: Pupil Dev Team
 date: 2014-02-20
 subtitle: We would like to introduce a new app for Pupil - Pupil Player - With this application we've finally added the crucial missing part of the toolchain. You can now visualize Pupil Capture recordings after the fact using the app with GUI...
 featured_img: "../../../../media/images/blog/pp.png"
+featured_img_thumb: "../../../../media/images/blog/thumb/pp.png"
 ---
 
 We would like to introduce a new app for Pupil - **Pupil Player** - With this application we've finally added the crucial missing part of the toolchain. You can now visualize Pupil Capture recordings after the fact using the app with GUI. 

--- a/contents/articles/2014-03_038-release/index.md
+++ b/contents/articles/2014-03_038-release/index.md
@@ -4,6 +4,7 @@ author: Pupil Dev Team
 date: 2014-03-25
 subtitle: We are happy to announce the release of new bundles for Pupil Capture & Pupil Player (v0.3.8). Bundles contain all the work that has been done in the last month. We have been working on many small but hopefully useful improvements...
 featured_img: "../../../../media/images/blog/v0.3.8_release_tag.png"
+featured_img_thumb: "../../../../media/images/blog/thumb/v0.3.8_release_tag.png"
 ---
 
 We are happy to announce the release of new bundles for Pupil Capture & Pupil Player (v0.3.8). Bundles contain all the work that has been done in the last month. We have been working on many small but hopefully useful improvements.

--- a/contents/articles/2014-05_039-release/index.md
+++ b/contents/articles/2014-05_039-release/index.md
@@ -4,6 +4,7 @@ author: Pupil Dev Team
 date: 2014-05-21
 subtitle: We are pleased to announce another release of Pupil Player and Pupil Capture software...
 featured_img: "../../../../media/images/blog/v0.3.9_release_tag.png"
+featured_img_thumb: "../../../../media/images/blog/thumb/v0.3.9_release_tag.png"
 ---
 
 We are pleased to announce another release of **Pupil Player** and **Pupil Capture** software. We usually aim to push new features every month, but we had been working on our [Technical Report](http://arxiv.org/abs/1405.0006 "Pervasive Eye Tracking and Mobile Gaze-based Interaction") and improved Pupil Pro Headsets -- available soon! Therefore we skipped one release cycle. Here's the list of new features and fixes:

--- a/contents/articles/2014-05_arxiv-report/index.md
+++ b/contents/articles/2014-05_arxiv-report/index.md
@@ -4,6 +4,7 @@ author: Pupil Dev Team
 date: 2014-05-12
 subtitle: We just completed a draft of a technical report on Pupil titled -- Pupil - An Open Source Platform for Pervasive Eye Tracking and Mobile Gaze-based Interaction -- have released it on arxiv.org...
 featured_img: "../../../media/images/blog/pupil-technical-report-1.png"
+featured_img_thumb: "../../../media/images/blog/thumb/pupil-technical-report-1.png"
 ---
 
 We just completed a draft of a technical report on Pupil titled - *Pupil: An Open Source Platform for Pervasive Eye Tracking and Mobile Gaze-based Interaction* - have released it on arxiv.org. 

--- a/contents/articles/2014-07_0392-release/index.md
+++ b/contents/articles/2014-07_0392-release/index.md
@@ -4,6 +4,7 @@ author: Pupil Dev Team
 date: 2014-07-10
 subtitle: We have been doing a lot of work recently on the back-end of Pupil Capture and Player, which will allow for much greater control in the way video and audio are captured, encoded, and decoded. While back-end changes are not yet available for use, we just wanted to say that we're working on it and hope to release changes within the next few weeks...
 featured_img: "../../../media/images/box_demo_v0392.png"
+featured_img_thumb: "../../../media/images/thumb/box_demo_v0392.png"
 ---
 
 We have been doing a lot of work recently on the back-end of Pupil Capture and Player, which will allow for much greater control in the way video and audio are captured, encoded, and decoded. While back-end changes are not yet available for use, we just wanted to say that we're working on it and hope to release changes within the next few weeks.

--- a/contents/articles/2014-07_0392-release/index.md
+++ b/contents/articles/2014-07_0392-release/index.md
@@ -3,8 +3,8 @@ title: Pupil Player - Incremental Release v0.3.9.2
 author: Pupil Dev Team
 date: 2014-07-10
 subtitle: We have been doing a lot of work recently on the back-end of Pupil Capture and Player, which will allow for much greater control in the way video and audio are captured, encoded, and decoded. While back-end changes are not yet available for use, we just wanted to say that we're working on it and hope to release changes within the next few weeks...
-featured_img: "../../../media/images/box_demo_v0392.png"
-featured_img_thumb: "../../../media/images/thumb/box_demo_v0392.png"
+featured_img: "../../../media/images/blog/box_demo_v0392.png"
+featured_img_thumb: "../../../media/images/blog/thumb/box_demo_v0392.png"
 ---
 
 We have been doing a lot of work recently on the back-end of Pupil Capture and Player, which will allow for much greater control in the way video and audio are captured, encoded, and decoded. While back-end changes are not yet available for use, we just wanted to say that we're working on it and hope to release changes within the next few weeks.

--- a/contents/articles/2014-11_040-roadmap/index.md
+++ b/contents/articles/2014-11_040-roadmap/index.md
@@ -4,6 +4,7 @@ author: Pupil Dev Team
 date: 2014-11-14
 subtitle: Its been a while since we've posted any development updates. The reason for the silence is because we've been busy developing new hardware, and are preparing for major changes in the upcoming v0.4.0 releases for Pupil Capture and Pupil Player...
 featured_img: "../../../../media/images/blog/demo_screenshot_20141124.png"
+featured_img_thumb: "../../../../media/images/blog/thumb/demo_screenshot_20141124.png"
 ---
 
 Its been a while since we've posted any development updates. The reason for the silence is because we've been busy developing new hardware, and are preparing for major changes in the upcoming v0.4.0 releases for Pupil Capture and Pupil Player. 

--- a/contents/articles/2015-02_040-release/index.md
+++ b/contents/articles/2015-02_040-release/index.md
@@ -4,6 +4,7 @@ author: Pupil Dev Team
 date: 2015-02-25
 subtitle: We are very excited to release our latest set of improvements to the Pupil project. This is the biggest release so far. We have created 5 new libraries and made over 300 commits to the Pupil source...
 featured_img: "../../../../media/images/blog/v0.4.0_release_tag.png"
+featured_img_thumb: "../../../../media/images/blog/thumb/v0.4.0_release_tag.png"
 ---
 
 We are very excited to release our latest set of improvements to the Pupil project. This is the biggest release so far. We have created 5 new libraries and made over 300 commits to the Pupil source.  

--- a/contents/articles/2015-07_pupil-v0.5.0-release/index.md
+++ b/contents/articles/2015-07_pupil-v0.5.0-release/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: We are very excited to release our latest set of improvements to the Pupil project with v0.5.x ...
  featured_img: "../../../../media/images/blog/v0.5.0_release_tag.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/v0.5.0_release_tag.png"
  ---
 
 We are very excited to release our latest set of improvements to the Pupil project

--- a/contents/articles/2015-08_new-hardware-and-new-website/index.md
+++ b/contents/articles/2015-08_new-hardware-and-new-website/index.md
@@ -3,8 +3,8 @@
  date: Tue Aug 25 2015 16:12:16 GMT+0700 (ICT)
  author: Pupil Dev Team
  subtitle: Two big updates -- New Hardware and a brand new website...
- featured_img: "../../../../media/images/store_additional_products/e120upgrade.png"
- featured_img_thumb: "../../../../media/images/thumb/store_additional_products/e120upgrade.png"
+ featured_img: "../../../../media/images/blog/e120upgrade.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/e120upgrade.png"
  ---
 
  We are excited to announce two big updates. 

--- a/contents/articles/2015-08_new-hardware-and-new-website/index.md
+++ b/contents/articles/2015-08_new-hardware-and-new-website/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: Two big updates -- New Hardware and a brand new website...
  featured_img: "../../../../media/images/store_additional_products/e120upgrade.png"
+ featured_img_thumb: "../../../../media/images/thumb/store_additional_products/e120upgrade.png"
  ---
 
  We are excited to announce two big updates. 

--- a/contents/articles/2015-09_hiring-android-developer/index.md
+++ b/contents/articles/2015-09_hiring-android-developer/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: We are looking to hire an Android software developer to join the Pupil Labs team...
  featured_img: ""
+ featured_img_thumb: ""
  ---
 
 We are looking to hire an Android software developer to develop an application that can capture  video and audio from USB (UVC) webcams utilizing [this library](https://github.com/saki4510t/UVCCamera), record video and audio on the Android device, and stream video and audio over the network. The Android application will interface with Pupil Capture (eye tracking software). The application will form a basis for continuous development of a mobile egocentric vision and eye tracking platform.

--- a/contents/articles/2015-09_pupil-capture-and-player-v0.6/index.md
+++ b/contents/articles/2015-09_pupil-capture-and-player-v0.6/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: Pupil Capture and Pupil Player v0.6 release notes. New features include Pupil Sync, visible logging feedback, and restructred video capture.
  featured_img: "../../../../media/images/blog/v0.6.0_release_tag.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/v0.6.0_release_tag.png"
  ---
 
 <a href="https://github.com/pupil-labs/pupil/releases" class="Button">Download Pupil v0.6.0</a>

--- a/contents/articles/2015-09_pupil-in-space/index.md
+++ b/contents/articles/2015-09_pupil-in-space/index.md
@@ -3,8 +3,8 @@
  date: Fri Sep 25 2015 21:27:19 GMT+0700 (ICT)
  author: Pupil Dev Team
  subtitle: Pupil is now in SPACE! Two Pupil headset went up to the ISS on Soyuz 44s...
- featured_img: "../../../../media/images/pupil_in_space_web.jpg"
- featured_img_thumb: "../../../../media/images/thumb/pupil_in_space_web.jpg"
+ featured_img: "../../../../media/images/blog/pupil_in_space_web.jpg"
+ featured_img_thumb: "../../../../media/images/blog/thumb/pupil_in_space_web.jpg"
 ---
 
 Pupil is now in SPACE! Two Pupil headset went up to the ISS on Soyuz 44s.

--- a/contents/articles/2015-09_pupil-in-space/index.md
+++ b/contents/articles/2015-09_pupil-in-space/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: Pupil is now in SPACE! Two Pupil headset went up to the ISS on Soyuz 44s...
  featured_img: "../../../../media/images/pupil_in_space_web.jpg"
+ featured_img_thumb: "../../../../media/images/thumb/pupil_in_space_web.jpg"
 ---
 
 Pupil is now in SPACE! Two Pupil headset went up to the ISS on Soyuz 44s.

--- a/contents/articles/2016-02_pupil-for-hmd/index.md
+++ b/contents/articles/2016-02_pupil-for-hmd/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: New Products - Eye tracking for VR and AR head mounted displays. Oculus Rift DK2, Epson Moverio BT-200...
  featured_img: "../../../../media/images/store_vr_ar/oculusdk2m.png"
+ featured_img_thumb: "../../../../media/images/thumb/store_vr_ar/oculusdk2m.png"
  ---
 
 We have just released our eye tracking add-on cups for the Oculus DK2 and camera mounts for the Epson Moverio BT-200. Both are available on the [store](/store#products).

--- a/contents/articles/2016-02_pupil-for-hmd/index.md
+++ b/contents/articles/2016-02_pupil-for-hmd/index.md
@@ -4,7 +4,7 @@
  author: Pupil Dev Team
  subtitle: New Products - Eye tracking for VR and AR head mounted displays. Oculus Rift DK2, Epson Moverio BT-200...
  featured_img: "../../../../media/images/blog/oculusdk2m.png"
- featured_img_thumb: "../../../../media/images/blog/thumb/store_vr_ar/oculusdk2m.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/oculusdk2m.png"
  ---
 
 We have just released our eye tracking add-on cups for the Oculus DK2 and camera mounts for the Epson Moverio BT-200. Both are available on the [store](/store#products).

--- a/contents/articles/2016-02_pupil-for-hmd/index.md
+++ b/contents/articles/2016-02_pupil-for-hmd/index.md
@@ -3,8 +3,8 @@
  date: Tue Feb 23 2016 09:23:14 GMT+0700 (ICT)
  author: Pupil Dev Team
  subtitle: New Products - Eye tracking for VR and AR head mounted displays. Oculus Rift DK2, Epson Moverio BT-200...
- featured_img: "../../../../media/images/store_vr_ar/oculusdk2m.png"
- featured_img_thumb: "../../../../media/images/thumb/store_vr_ar/oculusdk2m.png"
+ featured_img: "../../../../media/images/blog/oculusdk2m.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/store_vr_ar/oculusdk2m.png"
  ---
 
 We have just released our eye tracking add-on cups for the Oculus DK2 and camera mounts for the Epson Moverio BT-200. Both are available on the [store](/store#products).

--- a/contents/articles/2016-03_pupil-v0.7-release-notes/index.md
+++ b/contents/articles/2016-03_pupil-v0.7-release-notes/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: We are happy to release v.0.7 of the Pupil platform. This is a major release with lots of changes. Including the 3d pupil detector...
  featured_img: "../../../../media/images/blog/v0.7.0_release_tag.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/v0.7.0_release_tag.png"
  ---
 
 <script src="//cdn.rawgit.com/showdownjs/showdown/1.3.0/dist/showdown.min.js"></script>

--- a/contents/articles/2016-04_hmd-eyes/index.md
+++ b/contents/articles/2016-04_hmd-eyes/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: We propose a community driven, open source suite of software building blocks for eye tracking in Head Mounted Displays...
  featured_img: "../../../../media/images/blog/plopski_itoh_corneal-reflection.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/plopski_itoh_corneal-reflection.png"
  --- 
 
 After receiving many requests from the community, we have taken the first steps towards supporting eye tracking in Virtual Reality and Augmented Reality (VR/AR) head mounted displays (HMDs) with the release of eye tracking add-ons for Oculus DK2 and Epson Moverio BT-200. We are committed to bringing eye tracking to VR/AR HMDS, and plan to create new hardware for the latest VR and AR hardware when it hits the market. 

--- a/contents/articles/2016-04_pupil-user-guide-updates/index.md
+++ b/contents/articles/2016-04_pupil-user-guide-updates/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: New video walkthroughs for Pupil Capture and Player and brand new getting started guide...
  featured_img: "../../../../media/images/blog/v0.7_walkthrough.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/v0.7_walkthrough.png"
  ---
 
 We have just finished updating Pupil docs so that they cover new features in the v0.7 release. This update includes walkthrough videos for Pupil Capture and Pupil Player, as well as a new getting started guide. 

--- a/contents/articles/2016-04_pupil-v0.7.5-release-notes/index.md
+++ b/contents/articles/2016-04_pupil-v0.7.5-release-notes/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: Release notes for v0.7.5 (minor release) of the Pupil platform. Includes improvements to the surface tracker, bug fixes, and performance improvements...
  featured_img: "../../../../media/images/blog/v0.7.5_release_tag.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/v0.7.5_release_tag.png"
  ---
 
 <script src="//cdn.rawgit.com/showdownjs/showdown/1.3.0/dist/showdown.min.js"></script>

--- a/contents/articles/2016-05_eyewear-computers-for-hci/index.md
+++ b/contents/articles/2016-05_eyewear-computers-for-hci/index.md
@@ -4,6 +4,7 @@ date: Mon May 02 2016 00:00:00 GMT+0700 (ICT)
 author: Pupil Dev Team
 subtitle: Pupil featured in "Eyewear Computers for Human-Computer Interaction", ACM Interactions, Volume 23...
 featured_img: "../../../../media/images/blog/eyewear_computing_hci_acm_2016.png"
+featured_img_thumb: "../../../../media/images/blog/thumb/eyewear_computing_hci_acm_2016.png"
 ---
 
 Pupil is featured in Andreas Bulling (Pupil Labs partner) and Kai Kunze's article – "Eyewear Computer for Human-Computer Interaction", _ACM Interactions_, May-June 2016.

--- a/contents/articles/2016-05_pupil-v0.7.6-release-notes/index.md
+++ b/contents/articles/2016-05_pupil-v0.7.6-release-notes/index.md
@@ -3,7 +3,8 @@
  date: Wed May 11 2016 15:55:37 GMT+0700 (ICT)
  author: Pupil Dev Team
  subtitle: Release notes for v0.7.6 (minor release) of the Pupil platform. Includes improvements to the video backend, improved logging, and new plugins...
- featured_img: "../../../../media/images/blog/v0.7.6_release_tag.png" 
+ featured_img: "../../../../media/images/blog/v0.7.6_release_tag.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/v0.7.6_release_tag.png" 
  ---
 
 <script src="//cdn.rawgit.com/showdownjs/showdown/1.3.0/dist/showdown.min.js"></script>

--- a/contents/articles/2016-06_pupil-in-google-cardboard/index.md
+++ b/contents/articles/2016-06_pupil-in-google-cardboard/index.md
@@ -3,7 +3,8 @@
  date: Wed Jun 01 2016 10:44:45 GMT-0500 (CDT)
  author: Pupil Dev Team
  subtitle: Eye Square has integrated Pupil in Google Cardboard for product and in-store shopping studies...
- featured_img: "../../../../media/images/blog/eye_square_vr.png"  
+ featured_img: "../../../../media/images/blog/eye_square_vr.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/eye_square_vr.png"  
  ---
 
 [Eye Square](http://www.eye-square.com/itx/) has combined a Pupil eye tracking headset with Google Cardboard to enable VR product and in-store studies. 

--- a/contents/articles/2016-07_new-headset-color-dye-process/index.md
+++ b/contents/articles/2016-07_new-headset-color-dye-process/index.md
@@ -4,6 +4,7 @@ date: Thu Jul 07 2016 09:47:48 GMT+0700 (ICT)
 author: Pupil Dev Team
 subtitle: A new Pupil headset color is coming soon. We are experimenting with an in-house dyeing process to perfect the finish of our headsets...
 featured_img: "../../../../media/images/blog/dmk-headset.jpg"
+featured_img_thumb: "../../../../media/images/blog/thumb/dmk-headset.jpg"
 ---
 
 <div class="Feature-video-container-16by9">

--- a/contents/articles/2016-07_new-usb-c-clip/index.md
+++ b/contents/articles/2016-07_new-usb-c-clip/index.md
@@ -3,7 +3,8 @@ title: USB C Clip
 date: Sat Jul 09 2016 07:00:00 GMT+0700 (ICT)
 author: Pupil Dev Team
 subtitle: We are excited to share with you our new USB C clip...
-featured_img: "../../../../media/images/blog/usb-c.jpg" 
+featured_img: "../../../../media/images/blog/usb-c.jpg"
+featured_img_thumb: "../../../../media/images/blog/thumb/usb-c.jpg" 
 ---
 
 We are excited to announce the release of our new USB C clip for Pupil hardware.

--- a/contents/articles/2016-07_pupil-service/index.md
+++ b/contents/articles/2016-07_pupil-service/index.md
@@ -4,6 +4,7 @@ date: Wed Jul 06 2016 08:47:48 GMT+0700 (ICT)
 author: Pupil Dev Team
 subtitle: Pupil Service is a new app in release v0.8.0...
 featured_img: "../../../../media/images/blog/pupil-service.png"
+featured_img_thumb: "../../../../media/images/blog/thumb/pupil-service.png"
 ---
 
 <div class="Grid-noWrap Grid--justifyCenter Grid--center u-padBottom--2">

--- a/contents/articles/2016-07_pupil-v0.8.0-release-notes/index.md
+++ b/contents/articles/2016-07_pupil-v0.8.0-release-notes/index.md
@@ -4,6 +4,7 @@
  author: Pupil Dev Team
  subtitle: Release notes for v0.8.0 for the Pupil Platform. Includes lots of changes to the message format, new inter proecss communication (IPC Backbone), and many more new features...
  featured_img: "../../../../media/images/blog/v0.8.0_release_tag.png"
+ featured_img_thumb: "../../../../media/images/blog/thumb/v0.8.0_release_tag.png"
  ---
 
 <script src="//cdn.rawgit.com/showdownjs/showdown/1.3.0/dist/showdown.min.js"></script>

--- a/templates/blog.jade
+++ b/templates/blog.jade
@@ -38,7 +38,7 @@ block main
 
       div.Grid.Grid--1of2.Grid--gutters-lg
         each article, i in articles.slice(1)
-          - var img_src = (article.metadata.featured_img ? article.metadata.featured_img : "https://placehold.it/800x600")
+          - var img_src = (article.metadata.featured_img_thumb ? article.metadata.featured_img_thumb : "https://placehold.it/800x600")
 
             div.Grid-cell
               div.Feature-image--blog-archive--wrapper


### PR DESCRIPTION
Added feature_img_thumb metadata for blogposts and changed the blog.jade to call thumbnail images instead of large images