### PR TITLE
VR-AR Table Overflow

### DIFF
--- a/templates/vr-ar.jade
+++ b/templates/vr-ar.jade
@@ -102,7 +102,7 @@ block main
                       td.Table--column #[strong Basic Capabilities]
                       td
                     tr
-                      td.Table--column Mono/Stereo
+                      td.Table--column Mono | Stereo
                       td Both, depending on desired setup
                     tr
                       td.Table--column Tracking Frequency
@@ -153,7 +153,7 @@ block main
                       td.Table--column Pupil Diameter
                       td Yes - units in pixels using 2d appearance, units in mm using 3d model
                     tr
-                      td.Table--column Velocity/Acceleration
+                      td.Table--column Velocity | Acceleration
                       td Can be implemented if desired
                     tr
                       td.Table--column Eye Accomodation
@@ -165,7 +165,7 @@ block main
                       td.Table--column Method
                       td 5 point
                     tr
-                      td.Table--column #[strong Power/Performance/Memory]
+                      td.Table--column #[strong Power | Performance | Memory]
                       td 
                     tr
                       td.Table--column Host CPU % Utilization 


### PR DESCRIPTION
fix tech-specs table overflow by adding spacing and pipe symbol between the words causing the overflow.