### PR TITLE
Imprint markdown overflow

### DIFF
--- a/contents/about/imprint.md
+++ b/contents/about/imprint.md
@@ -3,7 +3,7 @@ title: Imprint
 ---
 <h3 class="u-padBottom--0">Address</h3>
 
-Pupil Labs UG (haftungsbeschränkt) Gustav-Müller-Str. 7 10829 Berlin
+<p>Pupil Labs UG (haftungsbeschränkt) Gustav-Müller-Str. 7 10829 Berlin</p>
 
 <h3 class="u-padBottom--0">Contact</h3>E-Mail 
 
@@ -11,14 +11,14 @@ Pupil Labs UG (haftungsbeschränkt) Gustav-Müller-Str. 7 10829 Berlin
 
 <h3 class="u-padBottom--0">CEO</h3>
 
-Moritz Kassner
+<p>Moritz Kassner</p>
 
 <h3 class="u-padBottom--0">Registration</h3>
 
-Resitercourt/ Register id: District court Berlin (Charlottenburg) HRB 155541
+<p>Resitercourt/ Register id: District court Berlin (Charlottenburg) HRB 155541</p>
 
 <h3 class="u-padBottom--0">VAT ID</h3>
 
-gemäß § 27 a Umsatzsteuergesetz: DE293673193
+<p>gemäß § 27 a Umsatzsteuergesetz: DE293673193</p>
 
-Responsible for Content (nach § 10 Absatz 3 MDStV): Moritz Kassner (Address as above)
+<p>Responsible for Content (nach § 10 Absatz 3 MDStV): Moritz Kassner (Address as above)</p>

--- a/templates/about.jade
+++ b/templates/about.jade
@@ -93,7 +93,7 @@ block main
               div.Feature
                 h1.Feature-title--lg.u-textCenter.u-padBottom--1= imprint_meta.title
               div.Grid
-                div.Grid-cell.Grid-cell--full!= typogr(imprint_data.html).typogrify()
+                div.Grid-cell.Grid-cell--full!= imprint_data.html
 
 
     //- div.u-padBottom--5


### PR DESCRIPTION
Fix imprint overflow on the About page caused by markdown parsing uppercase words to span elements.