### PR TITLE
Home Activity Overflow

### DIFF
--- a/assets/stylus/components/activity.styl
+++ b/assets/stylus/components/activity.styl
@@ -2,6 +2,8 @@
 ul.Activity
   word-wrap break-word
   list-style none
+  padding-left 5.5em
+  padding-right 5.5em
 
   li 
     // font-weight 700
@@ -15,6 +17,11 @@ ul.Activity
       // font-family $font-family-sans-serif-alt
       // font-size .85em
       // margin-left 1em
+        
+  @media $break-767
+    padding-left 0em
+    padding-right 0em
+
 
 .Activity-releaseEvent
   font-weight 700

--- a/templates/home.jade
+++ b/templates/home.jade
@@ -72,9 +72,8 @@ block main
                   h3.u-padBottom--0 Check out a snapshot of the most recent activity below.
               div(style="border-bottom: 2px #ddd solid")
             div.Grid-cell.Grid-cell--full.u-padTop--1
-              div.Grid.Grid--justifyCenter.Grid--center
-                  div(id="Home-activity")
-                    ul(id="Home-activity-list" class="Activity")
+              div(id="Home-activity")
+                ul(id="Home-activity-list" class="Activity")
 
     
     //- newsletter row


### PR DESCRIPTION
Fixed the github activity overflow on the home page.
Removed the flexbox causing the overflow and added padding with media break.