### PR TITLE
VRAR page - Add Hololens and BT300

### DIFF
--- a/templates/vr-ar.jade
+++ b/templates/vr-ar.jade
@@ -48,7 +48,7 @@ block main
             div.Feature
               h1 Hardware Add-Ons
           div.Grid-cell.Grid-cell--full.u-textCenter
-            div.Grid.Grid--gutters.Grid--1of3.Grid--bottom
+            div.Grid.Grid--gutters.Grid--1of2.Grid--bottom
               div.Grid-cell
                 div.Feature
                 figure.Feature-figure
@@ -57,8 +57,15 @@ block main
               div.Grid-cell
                 div.Feature
                 figure.Feature-figure
-                  img(class="Feature-image" src="../media/images/store_vr_ar/epsonbt200b.png" title="Epson BT-200 Add-on" alt="Epson BT-200 Add-on")
-                  p #[a(href="/store#vr-ar" title="Pupil Labs Store Epson BT-200 add-on") Epson BT-200 Add-on]              
+                  img(class="Feature-image" src="../media/images/store_vr_ar/addon_hololens.jpg" title="Microsoft Hololens Add-on" alt="Microsoft Hololens Binocular Add-on")
+                  p #[a(href="/store#vr-ar" title="Pupil Labs Store Microsoft Hololens Binocular Add-on") Microsoft Hololens Binocular Add-on]
+          div.Grid-cell.Grid-cell--full.u-textCenter
+            div.Grid.Grid--gutters.Grid--1of2.Grid--bottom        
+              div.Grid-cell
+                div.Feature
+                figure.Feature-figure
+                  img(class="Feature-image" src="../media/images/store_vr_ar/addon_epson_bt300b.jpg" title="Epson BT-300 Add-on" alt="Epson BT-300 Add-on")
+                  p #[a(href="/store#vr-ar" title="Pupil Labs Store Epson BT-300 add-on") Epson BT-300 Add-on]
               div.Grid-cell
                 div.Feature
                 figure.Feature-figure


### PR DESCRIPTION
Add hololens and bt300 to VRAR page in the hardware-addons section with 2x2 layout.