### PR TITLE
Enable RSS discovery in header

### DIFF
--- a/templates/includes/head.jade
+++ b/templates/includes/head.jade
@@ -55,7 +55,7 @@ head
   meta(http-equiv="Cache-control" max-age=86400 content="public")
 
   //- feed
-  //- link(rel='alternate', href=locals.url+'/feed.xml', type='application/rss+xml', title=locals.description)
+  link(rel='alternate', href=locals.url+'/feed.xml', type='application/rss+xml', title=locals.description)
   //
     |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~| 
     |      ___      ___         ___                        |


### PR DESCRIPTION
Maybe there was a good reason to hide the link to rss in header, but it makes hard to find it with rss reader. I even thought that there wasn't any rss feed for the blog at the beginning !