### PR TITLE
Blog for Picoflexx and LSL

### DIFF
--- a/contents/articles/2019-04_picoflexx-integration/index.md
+++ b/contents/articles/2019-04_picoflexx-integration/index.md
@@ -1,0 +1,20 @@
+--- 
+title: pmd Picoflexx Integration For Pupil Capture
+date: Fri Apr 05 2019 14:16:03 GMT+0700 (DST) 
+author: Pupil Dev Team 
+subtitle: We are happy to share the new Picoflexx backend for Pupil Capture...
+featured_img: ../../../../media/images/blog/picoflexx.png
+featured_img_thumb: ../../../../media/images/blog/picoflexx.png
+---
+
+<div class="Feature-image-wrapper" style="text-align:center;">
+	<img src="../../../../media/images/blog/picoflexx.png" class='Feature-image' alt="Vizard Pupil Labs integration"/>
+</div>
+<div class="small u-padBottom--2">Picoflexx running in Pupil Capture</div>
+
+We are happy to share the new [Picoflexx backend for Pupil Capture](https://github.com/pupil-labs/pupil-picoflexx) with you.
+It adds support for [pmd's 3d time-of-flight camera](https://pmdtec.com/picofamily/).
+For this plugin to work, you are required to [request a copy of pmd's proprietary software](https://pmdtec.com/picofamily/software/).
+
+<h4 class="u-padTop--1">Acknowledgments/Disclaimer</h4>
+This is a third-party contribution by [@Murnto](https://github.com/Murnto) and [@peteratBHVI](https://github.com/peteratBHVI).

--- a/contents/articles/2019-04_pupil-plugin-lsl-2.0/index.md
+++ b/contents/articles/2019-04_pupil-plugin-lsl-2.0/index.md
@@ -1,0 +1,21 @@
+--- 
+title: Pupil plugin for Lab Streaming Layer, 2.0
+date: Wed Apr 03 2019 13:16:03 GMT+0700 (DST) 
+author: Pupil Dev Team 
+subtitle: We are excited to announce the all new 2.0 version of the Pupil LSL Relay plugin for Pupil Capture...
+featured_img_thumb: ../../../../media/images/blog/Lab-Streaming-Layer.jpg
+subtag: yes
+---
+
+<div class="Grid Grid--center Grid--justifyCenter">
+	<img src="../../../../media/images/blog/Lab-Streaming-Layer.jpg" style="width:50%" class='Feature-image u-padBottom--1' alt="Lab Streaming Layer">
+</div>
+<div class="small u-padBottom--2">Image Source: [Qusp Product Portfolio](https://qusp.io/projects)</div>
+
+We are excited to announce the all new 2.0 version of the [Pupil LSL Relay plugin](https://github.com/labstreaminglayer/App-PupilLabs/releases/tag/v2.0) for Pupil Capture!
+
+[Lab Streaming Layer](https://github.com/sccn/labstreaminglayer/) (LSL) is a system that provides unified collection of measurement time series between programs, computers, and devices over a network for distributed signal transport, time synchronization, and data collection. LSL has an extensive range of supported measurement modalities including eye tracking.
+
+The new [Pupil LSL Relay plugin](https://github.com/labstreaminglayer/App-PupilLabs/releases/tag/v2.0) features a unified data outlet that follows the official [`Gaze Meta Data`](https://github.com/sccn/xdf/wiki/Gaze-Meta-Data) format. Additionally, Pupil Capture uses the LSL's framework clock for simpler and more precise time synchronization.
+
+See the [release notes](https://github.com/labstreaminglayer/App-PupilLabs/releases/tag/v2.0) for more details.

--- a/templates/blog.jade
+++ b/templates/blog.jade
@@ -33,7 +33,7 @@ block main
 
     each featured, i in newsArticles
       if i == 0
-        - var featured_inline_style = (featured.metadata.featured_img ? "background-color:#6f7679; background-image: url('"+featured.metadata.featured_img+"');" : "background: linear-gradient(to top right, #536DFE 0%, #75F0B4 100%);")
+        - var featured_inline_style = (featured.metadata.featured_img ? "background-color:#eeeeee; background-image: url('"+featured.metadata.featured_img+"');" : "background: linear-gradient(to top right, #536DFE 0%, #75F0B4 100%);")
         div.Site-content-container.Blog-container
           a(href=featured.url)
             div.Grid.card.Grid-featured-card.u-marginY--2
@@ -87,6 +87,8 @@ block main
                         div.Grid.Grid--justifySpaceBetween.Grid-column.Fill-height(style="color:#212121;")
                           div
                             if article.metadata.tag
+                              h5.Blog-topic-text(style="padding-bottom:6px !important;") Software Release
+                            else if article.metadata.subtag
                               h5.Blog-topic-text(style="padding-bottom:6px !important;") Software Release
                             else
                               h5.Blog-topic-text(style="padding-bottom:6px !important;") News


### PR DESCRIPTION
Since we have plugins we also release, i thought of updating the blog layout to check for a subtag so that it says Software Release instead of News like what we already do for Pupil releases.